### PR TITLE
More robust shell checking

### DIFF
--- a/node-reinstall.sh
+++ b/node-reinstall.sh
@@ -125,18 +125,39 @@ if (( $USE_NVM )); then
   # install the latest 0.10 version of node then set it as the default
   nvm install $NODE_VERSION
   nvm alias default $NODE_VERSION
-  if test -f $HOME/.zshrc; then
-    # you must "source" the NVM exports - yours are most likely in ~/.zshrc or ~/.bashrc or ~/.bash_profile and ~/.profile
-    source $HOME/.zshrc
-  elif test -f $HOME/.bashrc; then
-     # source $HOME/.bashrc
-    :
-  elif test -f $HOME/.bash_profile; then
-    # source $HOME/.bash_profile
-    :
-  elif test -f $HOME/.profile; then
-    # source $HOME/.profile
-    :
+  if [[ $SHELL =~ zsh$ ]]; then
+      if [ -f "$HOME/.zshrc" ]; then
+        echo "Sourcing your ~/.zshrc file."
+        source "$HOME/.zshrc"
+    elif [ -f "$HOME/.profile" ]; then
+        echo "Sourcing your ~/.profile file."
+        source "$HOME/.profile"
+      else
+        echo "Detected ZSH as your shell but did not find ~/.zshrc or ~/.profile"
+      fi
+  elif [[ $SHELL =~ bash$ ]]; then
+    if [ -f "$HOME/.bashrc" ]; then
+        echo "Sourcing your ~/.bashrc file."
+        source "$HOME/.bashrc"
+    elif [ -f "$HOME/.bash_profile" ]; then
+        echo "Sourcing your ~/.bash_profile file."
+        source "$HOME/.bash_profile"
+      elif [ -f "$HOME/.profile" ]; then
+        echo "Sourcing your ~/.profile file."
+        source "$HOME/.profile"
+    else
+        echo "Detected Bash as your shell but did not find a ~/.bashrc or ~/.bash_profile or ~/.profile"
+      fi
+  else
+    if [ -f "$HOME/.profile" ]; then
+        echo "Your Shell type was not Bash or ZSH, but I found a ~/.profile file."
+        echo "I will try to source the ~/.profile, but you may need to restart your terminal for this to take effect."
+        echo "Please open an issue at http://github.com/brock/node-reinstall/issues and report your shell type:"
+        echo "Your shell type is: ${SHELL}"
+        echo ""
+        echo "Sourcing your ~/.profile file."
+        source "$HOME/.profile"
+      fi
   fi
 elif (( $USE_NAVE )); then
   nave usemain $NODE_VERSION

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+if [[ $SHELL =~ zsh$ ]]; then
+  	if [ -f "$HOME/.zshrc" ]; then
+    	echo "Sourcing your ~/.zshrc file."
+	   	source "$HOME/.zshrc"
+	elif [ -f "$HOME/.profile" ]; then
+    	echo "Sourcing your ~/.profile file."
+    	source "$HOME/.profile"
+    else
+    	echo "Detected ZSH as your shell but did not find ~/.zshrc or ~/.profile"
+    fi
+elif [[ $SHELL =~ bash$ ]]; then
+	if [ -f "$HOME/.bashrc" ]; then
+    	echo "Sourcing your ~/.bashrc file."
+    	source "$HOME/.bashrc"
+	elif [ -f "$HOME/.bash_profile" ]; then
+    	echo "Sourcing your ~/.bash_profile file."
+    	source "$HOME/.bash_profile"
+    elif [ -f "$HOME/.profile" ]; then
+    	echo "Sourcing your ~/.profile file."
+    	source "$HOME/.profile"
+	else
+    	echo "Detected Bash as your shell but did not find a ~/.bashrc or ~/.bash_profile or ~/.profile"
+    fi
+else
+	if [ -f "$HOME/.profile" ]; then
+    	echo "Your Shell type was not Bash or ZSH, but I found a ~/.profile file."
+    	echo "I will try to source the ~/.profile, but you may need to restart your terminal for this to take effect."
+    	echo "Please open an issue at http://github.com/brock/node-reinstall/issues and report your shell type:"
+    	echo "Your shell type is: ${SHELL}"
+    	echo ""
+    	echo "Sourcing your ~/.profile file."
+    	source "$HOME/.profile"
+    fi
+fi


### PR DESCRIPTION
* adding a test.sh for shell testing and more robust shell checking to the installer

@mistergraphx @jwerle would you guys mind taking a look at the changes here? I noticed that we weren't actually sourcing any of the other profiles, and I thought we could be checking the value of the $SHELL anyway. 

If you want to change your shell back and forth between bash and zsh to test this, you could actually change your shell by running: `chsh -s /bin/bash -u $(whoami)` or `chsh -s /bin/zsh -u $(whoami)`

Or you could just add `SHELL=/bin/bash` to the top of test.sh or node-reinstall.sh files.